### PR TITLE
no need to explicitly define JokesResp struct

### DIFF
--- a/jokes.go
+++ b/jokes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/icelain/jokeapi"
 )
 
+/*
 type JokesResp struct {
 	Error    bool
 	Category string
@@ -16,6 +17,7 @@ type JokesResp struct {
 	Id       float64
 	Lang     string
 }
+*/
 
 func Joke() (string, error) {
 	jt := "single"


### PR DESCRIPTION
Hey, creator of the jokeapi-go client here. Stumbled across your project and just wanted to reach out and say that you don't need to directly declare the JokesResp struct(its included in the package)